### PR TITLE
Refactor: Update Celery task import in course_setup.py for clarity

### DIFF
--- a/src/entrenai/api/routers/course_setup.py
+++ b/src/entrenai/api/routers/course_setup.py
@@ -35,7 +35,7 @@ from src.entrenai.core.ai.ollama_wrapper import (
 from src.entrenai.core.clients.moodle_client import MoodleClient, MoodleAPIError
 from src.entrenai.core.clients.n8n_client import N8NClient
 from src.entrenai.core.db import PgvectorWrapper, PgvectorWrapperError  # Updated import
-from src.entrenai.core.tasks import process_moodle_file_task  # Import Celery task
+from src.entrenai.celery_tasks import forward_file_processing_to_api as process_moodle_file_task # Import Celery task for forwarding to API
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
The `refresh_course_files` endpoint in `course_setup.py` was importing `process_moodle_file_task` from `src.entrenai.core.tasks`, where it was commented out.

This commit changes the import to point to
`forward_file_processing_to_api` from `src.entrenai.celery_tasks` (aliased as `process_moodle_file_task` to minimize changes in the calling code).

Functionally, Celery was likely already routing the tasks correctly due to the task name (`entrenai.core.tasks.process_moodle_file_task`) being reused by `forward_file_processing_to_api`. This change makes the import explicit and the codebase easier to understand and maintain, ensuring that the code reflects the intended 'dumb Celery' architecture where Celery tasks delegate processing to the main Fahapi application via HTTP requests.